### PR TITLE
Auto-create devshell venv and fix ROCm wheel sourcing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.venv
+.venv*
 .zed

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.venv*
+.venv
 .zed

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ nix develop ./#cuda # Make sure change this based on what you are running
 cd ComfyUI
 python -m pip install -r requirements.txt
 ```
+Each `nix develop ./#<variant>` automatically creates and activates a variant-specific virtualenv (e.g. `.venv-cpu`, `.venv-cuda`, `.venv-rocm`). That means `which python` inside the shell will point to the corresponding venv, keeping incompatible torch wheels isolated. You can safely remove any old `.venv` directory that may still exist from previous versions.
+
+### AMD / ROCm
+Entering `nix develop .#rocm` automatically points `pip` at the ROCm wheel index (`https://download.pytorch.org/whl/rocm6.3`) while keeping PyPI as a fallback for everything else. After launching that shell, remove any stale venv (`rm -rf .venv-rocm`) and reinstall requirements so torch/vision/audio come from the ROCm repo instead of pulling CUDA builds.
 You may need to install different versions of the torch packages based on your hardware. Look at the [ComfyUI](https://github.com/comfyanonymous/ComfyUI/tree/v0.3.41?tab=readme-ov-file#manual-install-windows-linux) repo to make sure.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ nix develop ./#cuda # Make sure change this based on what you are running
 cd ComfyUI
 python -m pip install -r requirements.txt
 ```
-Each `nix develop ./#<variant>` automatically creates and activates a variant-specific virtualenv (e.g. `.venv-cpu`, `.venv-cuda`, `.venv-rocm`). That means `which python` inside the shell will point to the corresponding venv, keeping incompatible torch wheels isolated. You can safely remove any old `.venv` directory that may still exist from previous versions.
+Each `nix develop ./#<variant>` automatically creates and activates `.venv`, so `which python` inside the shell always points to a writable virtualenv instead of the read-only Nix store. If you run into issues, delete `.venv` and reinstall requirements.
 
 ### AMD / ROCm
-Entering `nix develop .#rocm` automatically points `pip` at the ROCm wheel index (`https://download.pytorch.org/whl/rocm6.3`) while keeping PyPI as a fallback for everything else. After launching that shell, remove any stale venv (`rm -rf .venv-rocm`) and reinstall requirements so torch/vision/audio come from the ROCm repo instead of pulling CUDA builds.
+Entering `nix develop .#rocm` automatically points `pip` at the ROCm wheel index (`https://download.pytorch.org/whl/rocm6.4`) while keeping PyPI as a fallback for everything else. After launching that shell, remove any stale venv (`rm -rf .venv`) and reinstall requirements so torch/vision/audio come from the ROCm repo instead of pulling CUDA builds.
 You may need to install different versions of the torch packages based on your hardware. Look at the [ComfyUI](https://github.com/comfyanonymous/ComfyUI/tree/v0.3.41?tab=readme-ov-file#manual-install-windows-linux) repo to make sure.
 
 ## Troubleshooting

--- a/impl.nix
+++ b/impl.nix
@@ -29,6 +29,9 @@ let
       ]
     else
       throw "You need to specify which variant you want: CPU, ROCm, or CUDA.";
+  variantLower = pkgs.lib.toLower variant;
+  rocmIndexUrl = "https://download.pytorch.org/whl/rocm6.3";
+  pythonForVenv = pkgs.python312;
 in
 pkgs.mkShell rec {
   name = "comfyui-shell";
@@ -60,12 +63,10 @@ pkgs.mkShell rec {
       libGLU
       libGL
       glib
+      zstd
     ];
 
-  venvDir = ".venv";
-  packages = with pkgs.python310Packages; [
-    venvShellHook
-  ];
+  venvDir = ".venv-${variantLower}";
 
   LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
   CUDA_PATH = pkgs.lib.optionalString (
@@ -76,4 +77,22 @@ pkgs.mkShell rec {
       "-L${
         (if variant == "CUDA" then pkgs.linuxPackages.nvidia_x11 else pkgs.linuxPackages.nvidia_x11_beta)
       }/lib";
+
+  shellHook =
+    ''
+      VENV_PATH="${venvDir}"
+      if [ ! -d "$VENV_PATH" ]; then
+        echo "Creating Python virtualenv at $VENV_PATH"
+        ${pythonForVenv}/bin/python -m venv "$VENV_PATH"
+      fi
+      # shellcheck disable=SC1090
+      source "$VENV_PATH/bin/activate"
+      export PIP_DISABLE_PIP_VERSION_CHECK=1
+    ''
+    + pkgs.lib.optionalString (variant == "ROCM") ''
+      export PIP_INDEX_URL="${rocmIndexUrl}"
+      export PIP_EXTRA_INDEX_URL="https://pypi.org/simple"
+      echo "ROCm devshell: pip will pull torch/vision/audio wheels from ${rocmIndexUrl}"
+      echo "If you previously installed CUDA wheels, run 'rm -rf ${venvDir}' before reinstalling requirements."
+    '';
 }

--- a/impl.nix
+++ b/impl.nix
@@ -29,8 +29,7 @@ let
       ]
     else
       throw "You need to specify which variant you want: CPU, ROCm, or CUDA.";
-  variantLower = pkgs.lib.toLower variant;
-  rocmIndexUrl = "https://download.pytorch.org/whl/rocm6.3";
+  rocmIndexUrl = "https://download.pytorch.org/whl/rocm6.4";
   pythonForVenv = pkgs.python312;
 in
 pkgs.mkShell rec {
@@ -66,7 +65,7 @@ pkgs.mkShell rec {
       zstd
     ];
 
-  venvDir = ".venv-${variantLower}";
+  venvDir = ".venv";
 
   LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
   CUDA_PATH = pkgs.lib.optionalString (


### PR DESCRIPTION
Running `nix develop .#rocm`, installing requirements, and launching ComfyUI still loaded CUDA wheels, so PyTorch tried to initialize NVIDIA and failed even on AMD hosts. I also ran into issues where the `VIRTUAL_ENV` would be empty when devshells were nested, meaning `python` fell back to the nix-store. This PR:

1. Automatically creates/activates `.venv` for every devshell variant to eliminate issues when nesting shells.
1. For the ROCm shell, sets `PIP_INDEX_URL=https://download.pytorch.org/whl/rocm6.4` (with PyPI as `PIP_EXTRA_INDEX_URL`) so torch/vision/audio come from AMD’s wheel repo while everything else still comes from PyPI.
1. Adds `zstd` to `buildInputs` to satisfy ROCm PyTorch’s `libzstd.so.1` dependency.
1. Documents the behavior in the README.

With these changes the ROCm devshell installs the correct wheels and ComfyUI recognizes AMD GPUs, while CUDA support remains unchanged.

Fixes #2 